### PR TITLE
Win32: Add VK_EXT_full_screen_exclusive support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,11 @@ if (GRANITE_VULKAN_MT)
     target_sources(granite PRIVATE vulkan/thread_id.hpp vulkan/thread_id.cpp)
 endif()
 
+if (WIN32)
+    target_compile_definitions(granite PRIVATE VK_USE_PLATFORM_WIN32_KHR)
+    target_compile_definitions(volk PRIVATE VK_USE_PLATFORM_WIN32_KHR)
+endif()
+
 if (NOT GRANITE_VULKAN_ONLY)
     if (NOT ANDROID)
         add_library(granite-application-entry STATIC application/application_entry.cpp)

--- a/renderer/post/hdr.cpp
+++ b/renderer/post/hdr.cpp
@@ -385,9 +385,9 @@ void setup_hdr_postprocess_compute(RenderGraph &graph, const std::string &input,
 		if (options.dynamic_exposure)
 			ubo_res = &tonemap.add_uniform_input("average-luminance");
 
-		tonemap.set_build_render_pass([&, interface = iface, ubo = ubo_res](Vulkan::CommandBuffer &cmd)
+		tonemap.set_build_render_pass([&, iface = iface, ubo = ubo_res](Vulkan::CommandBuffer &cmd)
 		                              {
-			                              tonemap_build_render_pass(tonemap, cmd, hdr_res, bloom_res, ubo, interface);
+			                              tonemap_build_render_pass(tonemap, cmd, hdr_res, bloom_res, ubo, iface);
 		                              });
 	}
 }
@@ -546,9 +546,9 @@ void setup_hdr_postprocess(RenderGraph &graph, const std::string &input, const s
 		if (options.dynamic_exposure)
 			ubo_res = &tonemap.add_uniform_input("average-luminance-updated");
 
-		tonemap.set_build_render_pass([&, interface = iface, ubo = ubo_res](Vulkan::CommandBuffer &cmd)
+		tonemap.set_build_render_pass([&, iface = iface, ubo = ubo_res](Vulkan::CommandBuffer &cmd)
 		                              {
-			                              tonemap_build_render_pass(tonemap, cmd, hdr_res, bloom_res, ubo, interface);
+			                              tonemap_build_render_pass(tonemap, cmd, hdr_res, bloom_res, ubo, iface);
 		                              });
 	}
 }

--- a/vulkan/vulkan.cpp
+++ b/vulkan/vulkan.cpp
@@ -372,6 +372,17 @@ bool Context::create_instance(const char **instance_ext, uint32_t instance_ext_c
 		ext.supports_debug_utils = true;
 	}
 
+	auto itr = find_if(instance_ext, instance_ext + instance_ext_count, [](const char *name) {
+		return strcmp(name, VK_KHR_SURFACE_EXTENSION_NAME) == 0;
+	});
+	bool has_surface_extension = itr != (instance_ext + instance_ext_count);
+
+	if (has_surface_extension && has_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME))
+	{
+		instance_exts.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+		ext.supports_surface_capabilities2 = true;
+	}
+
 #ifdef VULKAN_DEBUG
 	const auto has_layer = [&](const char *name) -> bool {
 		auto itr = find_if(begin(queried_layers), end(queried_layers), [name](const VkLayerProperties &e) -> bool {
@@ -679,6 +690,14 @@ bool Context::create_device(VkPhysicalDevice gpu_, VkSurfaceKHR surface, const c
 		ext.supports_google_display_timing = true;
 		enabled_extensions.push_back(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME);
 	}
+
+#ifdef _WIN32
+	if (ext.supports_surface_capabilities2 && has_extension(VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME))
+	{
+		ext.supports_full_screen_exclusive = true;
+		enabled_extensions.push_back(VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME);
+	}
+#endif
 
 #ifdef VULKAN_DEBUG
 	if (has_extension(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME))

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -76,6 +76,8 @@ struct DeviceFeatures
 	bool supports_vulkan_11_instance = false;
 	bool supports_vulkan_11_device = false;
 	bool supports_external_memory_host = false;
+	bool supports_surface_capabilities2 = false;
+	bool supports_full_screen_exclusive = false;
 	VkPhysicalDeviceSubgroupProperties subgroup_properties = {};
 	VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features = {};
 	VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features = {};


### PR DESCRIPTION
Tested on latest AMD 19.6.2 driver.

Force-disables automatic exclusive fullscreen because it's annoying. Trivial to add a toggle if needed at some point.