### PR TITLE
Fix potential leak of timestamp-related command buffer

### DIFF
--- a/vulkan/device.cpp
+++ b/vulkan/device.cpp
@@ -2505,7 +2505,10 @@ void Device::recalibrate_timestamps_fallback()
 	auto cmd = request_command_buffer_nolock(0, CommandBuffer::Type::Generic, false);
 	auto ts = write_timestamp_nolock(cmd->get_command_buffer(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 	if (!ts)
+	{
+		submit_discard(cmd);
 		return;
+	}
 	auto start_ts = Util::get_current_time_nsecs();
 	submit_nolock(cmd, nullptr, 0, nullptr);
 	wait_idle_nolock();


### PR DESCRIPTION
On my device -- without timestamp-support -- the leak causes a hang inside `DRAIN_FRAME_LOCK()` (when using `GRANITE_VULKAN_MT`; an assert elsewhere if not) as this command-buffer never completes.