### PR TITLE
Various WSI tweaks

### DIFF
--- a/vulkan/device.cpp
+++ b/vulkan/device.cpp
@@ -681,13 +681,11 @@ void Device::init_workarounds()
 	// UNDEFINED -> COLOR_ATTACHMENT_OPTIMAL stalls, so need to acquire async.
 	if (gpu_props.vendorID == VENDOR_ID_ARM)
 	{
-		LOGW("Workaround applied: Acquiring WSI images early on Mali.\n");
 		LOGW("Workaround applied: Emulating events as pipeline barriers.\n");
 		LOGW("Workaround applied: Optimize ALL_GRAPHICS_BIT barriers.\n");
 		LOGW("Workaround applied: Split binary timeline semaphores.\n");
 
 		// All performance related workarounds.
-		workarounds.wsi_acquire_barrier_is_expensive = true;
 		workarounds.emulate_event_as_pipeline_barrier = true;
 		workarounds.optimize_all_graphics_barrier = true;
 		workarounds.split_binary_timeline_semaphores = true;

--- a/vulkan/device.cpp
+++ b/vulkan/device.cpp
@@ -1688,6 +1688,7 @@ void Device::submit_queue(CommandBuffer::Type type, InternalFence *fence,
 			wsi.release->set_internal_sync_object();
 			composer.add_signal_semaphore(release, 0);
 			wsi.consumed = true;
+			wsi.present_queue = queue;
 		}
 		else
 		{
@@ -2068,6 +2069,12 @@ Semaphore Device::consume_release_semaphore()
 	auto ret = move(wsi.release);
 	wsi.release.reset();
 	return ret;
+}
+
+VkQueue Device::get_current_present_queue() const
+{
+	VK_ASSERT(wsi.present_queue);
+	return wsi.present_queue;
 }
 
 const Sampler &Device::get_stock_sampler(StockSampler sampler) const

--- a/vulkan/device.hpp
+++ b/vulkan/device.hpp
@@ -450,6 +450,7 @@ private:
 
 	void set_acquire_semaphore(unsigned index, Semaphore acquire);
 	Semaphore consume_release_semaphore();
+	VkQueue get_current_present_queue() const;
 
 	PipelineLayout *request_pipeline_layout(const CombinedResourceLayout &layout);
 	DescriptorSetAllocator *request_descriptor_set_allocator(const DescriptorSetLayout &layout, const uint32_t *stages_for_sets);
@@ -588,9 +589,10 @@ private:
 	{
 		Semaphore acquire;
 		Semaphore release;
-		bool consumed = false;
 		std::vector<ImageHandle> swapchain;
+		VkQueue present_queue = VK_NULL_HANDLE;
 		unsigned index = 0;
+		bool consumed = false;
 	} wsi;
 
 	struct QueueData

--- a/vulkan/quirks.hpp
+++ b/vulkan/quirks.hpp
@@ -48,7 +48,6 @@ struct ImplementationQuirks
 struct ImplementationWorkarounds
 {
 	bool emulate_event_as_pipeline_barrier = false;
-	bool wsi_acquire_barrier_is_expensive = false;
 	bool optimize_all_graphics_barrier = false;
 	bool force_store_in_render_pass = false;
 	bool broken_color_write_mask = false;

--- a/vulkan/render_pass.hpp
+++ b/vulkan/render_pass.hpp
@@ -170,7 +170,6 @@ private:
 	void setup_subpasses(const VkRenderPassCreateInfo &create_info);
 
 	void fixup_render_pass_workaround(VkRenderPassCreateInfo &create_info, VkAttachmentDescription *attachments);
-	void fixup_wsi_barrier(VkRenderPassCreateInfo &create_info, VkAttachmentDescription *attachments);
 };
 
 class Framebuffer : public Cookie, public NoCopyNoMove, public InternalSyncEnabled

--- a/vulkan/wsi.cpp
+++ b/vulkan/wsi.cpp
@@ -428,7 +428,7 @@ bool WSI::end_frame()
 #endif
 
 		auto present_ts = device->write_calibrated_timestamp();
-		VkResult overall = table->vkQueuePresentKHR(context->get_graphics_queue(), &info);
+		VkResult overall = table->vkQueuePresentKHR(device->get_current_present_queue(), &info);
 		device->register_time_interval("WSI", std::move(present_ts), device->write_calibrated_timestamp(), "present");
 
 #if defined(ANDROID) && 0

--- a/vulkan/wsi.cpp
+++ b/vulkan/wsi.cpp
@@ -356,21 +356,6 @@ bool WSI::begin_frame()
 
 			platform->event_swapchain_index(device.get(), swapchain_index);
 
-			if (device->get_workarounds().wsi_acquire_barrier_is_expensive)
-			{
-				// Acquire async. Use the async graphics queue, as it's most likely not being used right away.
-				device->add_wait_semaphore(CommandBuffer::Type::AsyncGraphics, acquire, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, true);
-				auto cmd = device->request_command_buffer(CommandBuffer::Type::AsyncGraphics);
-				cmd->image_barrier(device->get_swapchain_view(swapchain_index).get_image(),
-				                   VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-				                   VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0,
-				                   VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0);
-
-				// Get a new acquire semaphore.
-				acquire.reset();
-				device->submit(cmd, nullptr, 1, &acquire);
-			}
-
 			device->set_acquire_semaphore(swapchain_index, acquire);
 		}
 		else if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR ||


### PR DESCRIPTION
- Removes some obsolete workarounds
- Use a more correct workaround for binary/timeline split
- Present in the queue which actually consumes WSI