### PR TITLE
Refactor how multiple queues are handled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(GRANITE_VULKAN_THREAD_GROUP "Add thread group support to Vulkan backend."
 option(GRANITE_VULKAN_SPIRV_CROSS "Add reflection support to Vulkan backend." ON)
 option(GRANITE_VULKAN_SHADER_MANAGER_RUNTIME_COMPILER "Enable Vulkan GLSL runtime compiler." ON)
 option(GRANITE_VULKAN_MT "Make Vulkan backend thread-safe." ON)
+option(GRANITE_VULKAN_BETA "Enable provisional extension support." OFF)
 option(GRANITE_VULKAN_FOSSILIZE "Enable support for Fossilize." OFF)
 option(GRANITE_AUDIO "Enable Audio support." OFF)
 option(GRANITE_PLATFORM "Granite Platform" "GLFW")

--- a/application/platforms/application_libretro_utils.cpp
+++ b/application/platforms/application_libretro_utils.cpp
@@ -96,10 +96,10 @@ bool libretro_create_device(
 	vulkan_context->release_device();
 	context->gpu = vulkan_context->get_gpu();
 	context->device = vulkan_context->get_device();
-	context->presentation_queue = vulkan_context->get_graphics_queue();
-	context->presentation_queue_family_index = vulkan_context->get_graphics_queue_family();
-	context->queue = vulkan_context->get_graphics_queue();
-	context->queue_family_index = vulkan_context->get_graphics_queue_family();
+	context->presentation_queue = vulkan_context->get_queue_info().queues[Vulkan::QUEUE_INDEX_GRAPHICS];
+	context->presentation_queue_family_index = vulkan_context->get_queue_info().family_indices[Vulkan::QUEUE_INDEX_GRAPHICS];
+	context->queue = vulkan_context->get_queue_info().queues[Vulkan::QUEUE_INDEX_GRAPHICS];
+	context->queue_family_index = vulkan_context->get_queue_info().family_indices[Vulkan::QUEUE_INDEX_GRAPHICS];
 	return true;
 }
 

--- a/renderer/render_graph.cpp
+++ b/renderer/render_graph.cpp
@@ -2315,8 +2315,7 @@ void RenderGraph::physical_pass_handle_cpu_timeline(Vulkan::Device &device_,
 	// Queue up invalidates and change layouts.
 	for (auto &barrier : physical_pass.invalidate)
 	{
-		bool physical_graphics =
-				device->get_physical_queue_type(state.queue_type) == Vulkan::CommandBuffer::Type::Generic;
+		bool physical_graphics = device->get_physical_queue_type(state.queue_type) == Vulkan::QUEUE_INDEX_GRAPHICS;
 		physical_pass_handle_invalidate_barrier(barrier, state, physical_graphics);
 	}
 
@@ -2406,7 +2405,7 @@ void RenderGraph::enqueue_swapchain_scale_pass(Vulkan::Device &device_)
 	unsigned index = source_resource.get_physical_index();
 	auto &image = physical_attachments[index]->get_image();
 
-	auto &wait_semaphore = physical_queue_type == Vulkan::CommandBuffer::Type::Generic ?
+	auto &wait_semaphore = physical_queue_type == Vulkan::QUEUE_INDEX_GRAPHICS ?
 	                       physical_events[index].wait_graphics_semaphore : physical_events[index].wait_compute_semaphore;
 
 	auto target_layout = physical_dimensions[index].is_storage_image() ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -56,6 +56,10 @@ target_include_directories(granite-rapidjson INTERFACE
 add_library(granite-volk-headers INTERFACE)
 target_include_directories(granite-volk-headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/volk)
 target_include_directories(granite-volk-headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/khronos/vulkan-headers/include)
+if (GRANITE_VULKAN_BETA)
+    target_include_directories(granite-volk-headers INTERFACE
+            ${CMAKE_CURRENT_SOURCE_DIR}/khronos/vulkan-headers/include/vk_video)
+endif()
 
 # volk must be STATIC.
 add_library(granite-volk STATIC volk/volk.c volk/volk.h)
@@ -63,6 +67,9 @@ if (WIN32)
     target_compile_definitions(granite-volk PRIVATE VK_USE_PLATFORM_WIN32_KHR)
 else()
     target_link_libraries(granite-volk PRIVATE dl)
+endif()
+if (GRANITE_VULKAN_BETA)
+    target_compile_definitions(granite-volk PRIVATE VK_ENABLE_BETA_EXTENSIONS)
 endif()
 target_link_libraries(granite-volk PRIVATE granite-volk-headers)
 

--- a/vulkan/CMakeLists.txt
+++ b/vulkan/CMakeLists.txt
@@ -47,6 +47,10 @@ if (GRANITE_VULKAN_MT)
     endif()
 endif()
 
+if (GRANITE_VULKAN_BETA)
+    target_compile_definitions(granite-vulkan PUBLIC GRANITE_VULKAN_BETA)
+endif()
+
 if (GRANITE_VULKAN_FOSSILIZE)
     target_compile_definitions(granite-vulkan PUBLIC GRANITE_VULKAN_FOSSILIZE)
     target_sources(granite-vulkan PRIVATE device_fossilize.cpp)

--- a/vulkan/command_buffer.cpp
+++ b/vulkan/command_buffer.cpp
@@ -2466,7 +2466,7 @@ void CommandBuffer::end_threaded_recording()
 
 	if (has_profiling())
 	{
-		auto &query_pool = device->get_performance_query_pool(type);
+		auto &query_pool = device->get_performance_query_pool(device->get_physical_queue_type(type));
 		query_pool.end_command_buffer(cmd);
 	}
 

--- a/vulkan/command_buffer.hpp
+++ b/vulkan/command_buffer.hpp
@@ -206,10 +206,11 @@ public:
 	friend struct CommandBufferDeleter;
 	enum class Type
 	{
-		Generic,
-		AsyncGraphics,
-		AsyncCompute,
-		AsyncTransfer,
+		Generic = QUEUE_INDEX_GRAPHICS,
+		AsyncCompute = QUEUE_INDEX_COMPUTE,
+		AsyncTransfer = QUEUE_INDEX_TRANSFER,
+		VideoDecode = QUEUE_INDEX_VIDEO_DECODE,
+		AsyncGraphics = QUEUE_INDEX_COUNT, // Aliases with either Generic or AsyncCompute queue
 		Count
 	};
 

--- a/vulkan/context.hpp
+++ b/vulkan/context.hpp
@@ -24,6 +24,7 @@
 
 #include "vulkan_headers.hpp"
 #include "logging.hpp"
+#include "vulkan_common.hpp"
 #include <memory>
 #include <functional>
 
@@ -69,6 +70,10 @@ struct DeviceFeatures
 	bool supports_calibrated_timestamps = false;
 	bool supports_memory_budget = false;
 	bool supports_astc_decode_mode = false;
+	bool supports_sync2 = false;
+	bool supports_video_queue = false;
+	bool supports_video_decode_queue = false;
+	bool supports_video_decode_h264 = false;
 	VkPhysicalDeviceSubgroupProperties subgroup_properties = {};
 	VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_features = {};
 	VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_features = {};
@@ -93,6 +98,7 @@ struct DeviceFeatures
 	VkPhysicalDeviceMemoryPriorityFeaturesEXT memory_priority_features = {};
 	VkPhysicalDeviceASTCDecodeFeaturesEXT astc_decode_features = {};
 	VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT astc_hdr_features = {};
+	VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = {};
 };
 
 enum VendorID
@@ -109,6 +115,14 @@ enum ContextCreationFlagBits
 	CONTEXT_CREATION_DISABLE_BINDLESS_BIT = 1 << 0
 };
 using ContextCreationFlags = uint32_t;
+
+struct QueueInfo
+{
+	QueueInfo();
+	VkQueue queues[QUEUE_INDEX_COUNT] = {};
+	uint32_t family_indices[QUEUE_INDEX_COUNT];
+	uint32_t timestamp_valid_bits = 0;
+};
 
 class Context
 {
@@ -144,19 +158,9 @@ public:
 		return device;
 	}
 
-	VkQueue get_graphics_queue() const
+	const QueueInfo &get_queue_info() const
 	{
-		return graphics_queue;
-	}
-
-	VkQueue get_compute_queue() const
-	{
-		return compute_queue;
-	}
-
-	VkQueue get_transfer_queue() const
-	{
-		return transfer_queue;
+		return queue_info;
 	}
 
 	const VkPhysicalDeviceProperties &get_gpu_props() const
@@ -167,26 +171,6 @@ public:
 	const VkPhysicalDeviceMemoryProperties &get_mem_props() const
 	{
 		return mem_props;
-	}
-
-	uint32_t get_graphics_queue_family() const
-	{
-		return graphics_queue_family;
-	}
-
-	uint32_t get_compute_queue_family() const
-	{
-		return compute_queue_family;
-	}
-
-	uint32_t get_transfer_queue_family() const
-	{
-		return transfer_queue_family;
-	}
-
-	uint32_t get_timestamp_valid_bits() const
-	{
-		return timestamp_valid_bits;
 	}
 
 	void release_instance()
@@ -251,13 +235,7 @@ private:
 	VkPhysicalDeviceProperties gpu_props = {};
 	VkPhysicalDeviceMemoryProperties mem_props = {};
 
-	VkQueue graphics_queue = VK_NULL_HANDLE;
-	VkQueue compute_queue = VK_NULL_HANDLE;
-	VkQueue transfer_queue = VK_NULL_HANDLE;
-	uint32_t graphics_queue_family = VK_QUEUE_FAMILY_IGNORED;
-	uint32_t compute_queue_family = VK_QUEUE_FAMILY_IGNORED;
-	uint32_t transfer_queue_family = VK_QUEUE_FAMILY_IGNORED;
-	uint32_t timestamp_valid_bits = 0;
+	QueueInfo queue_info;
 	unsigned num_thread_indices = 1;
 
 	bool create_instance(const char **instance_ext, uint32_t instance_ext_count);

--- a/vulkan/vulkan_common.hpp
+++ b/vulkan/vulkan_common.hpp
@@ -49,4 +49,13 @@ using VulkanCache = Util::IntrusiveHashMap<T>;
 template <typename T>
 using VulkanCacheReadWrite = Util::IntrusiveHashMap<T>;
 #endif
+
+enum QueueIndices
+{
+	QUEUE_INDEX_GRAPHICS,
+	QUEUE_INDEX_COMPUTE,
+	QUEUE_INDEX_TRANSFER,
+	QUEUE_INDEX_VIDEO_DECODE,
+	QUEUE_INDEX_COUNT
+};
 }

--- a/vulkan/vulkan_headers.hpp
+++ b/vulkan/vulkan_headers.hpp
@@ -22,8 +22,12 @@
 
 #pragma once
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(VK_USE_PLATFORM_WIN32_KHR)
 #define VK_USE_PLATFORM_WIN32_KHR
+#endif
+
+#if defined(GRANITE_VULKAN_BETA) && !defined(VK_ENABLE_BETA_EXTENSIONS)
+#define VK_ENABLE_BETA_EXTENSIONS
 #endif
 
 #include "volk.h"


### PR DESCRIPTION
The existing implementation was completely inflexible,
so access all queues and their families by index instead.

Enable Vulkan video extensions and add a video decode queue.

This is provisional, so will guard this behind a config ...