### PR TITLE
Rewrite immutable sampler handling.

### DIFF
--- a/renderer/renderer.cpp
+++ b/renderer/renderer.cpp
@@ -56,7 +56,10 @@ enum GlobalDescriptorSetBindings
 
 	BINDING_GLOBAL_CLUSTER_TRANSFORM = 9,
 	BINDING_GLOBAL_CLUSTER_BITMASK = 10,
-	BINDING_GLOBAL_CLUSTER_RANGE = 11
+	BINDING_GLOBAL_CLUSTER_RANGE = 11,
+
+	BINDING_GLOBAL_LINEAR_SAMPLER = 14,
+	BINDING_GLOBAL_SHADOW_SAMPLER = 15
 };
 
 namespace Granite
@@ -441,6 +444,9 @@ void Renderer::bind_lighting_parameters(Vulkan::CommandBuffer &cmd, const Render
 	auto *combined = cmd.allocate_typed_constant_data<CombinedRenderParameters>(0, BINDING_GLOBAL_RENDER_PARAMETERS, 1);
 	memset(combined, 0, sizeof(*combined));
 
+	cmd.set_sampler(0, BINDING_GLOBAL_LINEAR_SAMPLER, StockSampler::LinearClamp);
+	cmd.set_sampler(0, BINDING_GLOBAL_SHADOW_SAMPLER, StockSampler::LinearShadow);
+
 	if (lighting->volumetric_fog)
 	{
 		cmd.set_texture(0, BINDING_GLOBAL_VOLUMETRIC_FOG, lighting->volumetric_fog->get_view(), StockSampler::LinearClamp);
@@ -686,6 +692,9 @@ void DeferredLightRenderer::render_light(Vulkan::CommandBuffer &cmd, const Rende
 	cmd.set_blend_factors(VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ONE);
 	cmd.set_blend_op(VK_BLEND_OP_ADD);
 	CommandBufferUtil::set_fullscreen_quad_vertex_state(cmd);
+
+	cmd.set_sampler(0, BINDING_GLOBAL_LINEAR_SAMPLER, StockSampler::LinearClamp);
+	cmd.set_sampler(0, BINDING_GLOBAL_SHADOW_SAMPLER, StockSampler::LinearShadow);
 
 	auto &device = cmd.get_device();
 	auto *program = device.get_shader_manager().register_graphics("builtin://shaders/lights/directional.vert",

--- a/vulkan/command_buffer.cpp
+++ b/vulkan/command_buffer.cpp
@@ -2047,7 +2047,7 @@ void CommandBuffer::flush_descriptor_set(uint32_t set)
 		for (unsigned i = 0; i < array_size; i++)
 		{
 			h.u64(bindings.cookies[set][binding + i]);
-			if (!has_immutable_sampler(set_layout, binding + i))
+			if ((set_layout.immutable_sampler_mask & (1u << (binding + i))) == 0)
 			{
 				h.u64(bindings.secondary_cookies[set][binding + i]);
 				VK_ASSERT(bindings.bindings[set][binding + i].image.fp.sampler != VK_NULL_HANDLE);

--- a/vulkan/format.hpp
+++ b/vulkan/format.hpp
@@ -255,14 +255,6 @@ static inline VkDeviceSize format_get_layer_size(VkFormat format, VkImageAspectF
 	return size;
 }
 
-enum class YCbCrFormat
-{
-	YUV420P_3PLANE,
-	YUV444P_3PLANE,
-	YUV422P_3PLANE,
-	Count
-};
-
 static inline unsigned format_ycbcr_num_planes(VkFormat format)
 {
 	switch (format)
@@ -293,20 +285,6 @@ static inline unsigned format_ycbcr_num_planes(VkFormat format)
 
 	default:
 		return 1;
-	}
-}
-
-static inline unsigned format_ycbcr_num_planes(YCbCrFormat format)
-{
-	switch (format)
-	{
-	case YCbCrFormat::YUV420P_3PLANE:
-	case YCbCrFormat::YUV422P_3PLANE:
-	case YCbCrFormat::YUV444P_3PLANE:
-		return 3;
-
-	default:
-		return 0;
 	}
 }
 
@@ -352,51 +330,4 @@ static inline void format_ycbcr_downsample_dimensions(VkFormat format, VkImageAs
 	}
 #undef fmt
 }
-
-static inline unsigned format_ycbcr_downsample_ratio_log2(YCbCrFormat format, unsigned dim, unsigned plane)
-{
-	switch (format)
-	{
-	case YCbCrFormat::YUV420P_3PLANE:
-		return plane > 0 ? 1 : 0;
-	case YCbCrFormat::YUV422P_3PLANE:
-		return plane > 0 && dim == 0 ? 1 : 0;
-
-	default:
-		return 0;
-	}
-}
-
-static inline VkFormat format_ycbcr_plane_vk_format(YCbCrFormat format, unsigned plane)
-{
-	switch (format)
-	{
-	case YCbCrFormat::YUV420P_3PLANE:
-		return VK_FORMAT_R8_UNORM;
-	case YCbCrFormat::YUV422P_3PLANE:
-		return plane > 0 ? VK_FORMAT_R8G8_UNORM : VK_FORMAT_R8_UNORM;
-	case YCbCrFormat::YUV444P_3PLANE:
-		return VK_FORMAT_R8_UNORM;
-
-	default:
-		return VK_FORMAT_UNDEFINED;
-	}
-}
-
-static inline VkFormat format_ycbcr_planar_vk_format(YCbCrFormat format)
-{
-	switch (format)
-	{
-	case YCbCrFormat::YUV420P_3PLANE:
-		return VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
-	case YCbCrFormat::YUV422P_3PLANE:
-		return VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM;
-	case YCbCrFormat::YUV444P_3PLANE:
-		return VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM;
-
-	default:
-		return VK_FORMAT_UNDEFINED;
-	}
-}
-
 }

--- a/vulkan/image.cpp
+++ b/vulkan/image.cpp
@@ -146,47 +146,6 @@ Image::~Image()
 	}
 }
 
-YCbCrImage::YCbCrImage(Device *device_, YCbCrFormat format_, ImageHandle image_, const ImageHandle *planes_, unsigned num_planes_)
-	: device(device_), format(format_), num_planes(num_planes_)
-{
-	VK_ASSERT(num_planes <= 3);
-	image = std::move(image_);
-	image->set_internal_sync_object();
-	image->get_view().set_internal_sync_object();
-
-	for (unsigned i = 0; i < num_planes; i++)
-	{
-		planes[i] = planes_[i];
-		planes[i]->set_internal_sync_object();
-		planes[i]->get_view().set_internal_sync_object();
-	}
-}
-
-YCbCrImage::~YCbCrImage()
-{
-}
-
-Image &YCbCrImage::get_ycbcr_image()
-{
-	return *image;
-}
-
-Image &YCbCrImage::get_plane_image(unsigned plane)
-{
-	VK_ASSERT(plane < num_planes);
-	return *planes[plane];
-}
-
-unsigned YCbCrImage::get_num_planes() const
-{
-	return num_planes;
-}
-
-YCbCrFormat YCbCrImage::get_ycbcr_format() const
-{
-	return format;
-}
-
 const Buffer &LinearHostImage::get_host_visible_buffer() const
 {
 	return *cpu_image;
@@ -259,11 +218,6 @@ void ImageViewDeleter::operator()(ImageView *view)
 void ImageDeleter::operator()(Image *image)
 {
 	image->device->handle_pool.images.free(image);
-}
-
-void ImageDeleter::operator()(YCbCrImage *image)
-{
-	image->device->handle_pool.ycbcr_images.free(image);
 }
 
 void LinearHostImageDeleter::operator()(LinearHostImage *image)

--- a/vulkan/image.hpp
+++ b/vulkan/image.hpp
@@ -307,6 +307,8 @@ enum class ImageDomain
 	LinearHost
 };
 
+class ImmutableYcbcrConversion;
+
 struct ImageCreateInfo
 {
 	ImageDomain domain = ImageDomain::Physical;
@@ -327,6 +329,7 @@ struct ImageCreateInfo
 	};
 	const DeviceAllocation **memory_aliases = nullptr;
 	unsigned num_memory_aliases = 0;
+	const ImmutableYcbcrConversion *ycbcr_conversion = nullptr;
 
 	static ImageCreateInfo immutable_image(const TextureFormatLayout &layout)
 	{
@@ -447,20 +450,11 @@ struct ImageCreateInfo
 	}
 };
 
-struct YCbCrImageCreateInfo
-{
-	YCbCrFormat format = YCbCrFormat::YUV420P_3PLANE;
-	unsigned width = 0;
-	unsigned height = 0;
-};
-
 class Image;
-class YCbCrImage;
 
 struct ImageDeleter
 {
 	void operator()(Image *image);
-	void operator()(YCbCrImage *image);
 };
 
 enum class Layout
@@ -628,29 +622,6 @@ private:
 };
 
 using ImageHandle = Util::IntrusivePtr<Image>;
-
-class YCbCrImage : public Util::IntrusivePtrEnabled<YCbCrImage, ImageDeleter, HandleCounter>
-{
-public:
-	friend struct ImageDeleter;
-	~YCbCrImage();
-	Image &get_ycbcr_image();
-	Image &get_plane_image(unsigned plane);
-	unsigned get_num_planes() const;
-	YCbCrFormat get_ycbcr_format() const;
-
-private:
-	friend class Util::ObjectPool<YCbCrImage>;
-	YCbCrImage(Device *device, YCbCrFormat format, ImageHandle image, const ImageHandle *planes, unsigned num_planes);
-
-	Device *device;
-	YCbCrFormat format;
-	ImageHandle image;
-	ImageHandle planes[3];
-	unsigned num_planes;
-};
-
-using YCbCrImageHandle = Util::IntrusivePtr<YCbCrImage>;
 
 class LinearHostImage;
 struct LinearHostImageDeleter

--- a/vulkan/managers/shader_manager.hpp
+++ b/vulkan/managers/shader_manager.hpp
@@ -61,10 +61,12 @@ public:
 		Util::Hash spirv_hash = 0;
 		std::vector<uint32_t> spirv;
 		std::vector<std::pair<std::string, int>> defines;
+		std::unique_ptr<ImmutableSamplerBank> sampler_bank;
 		unsigned instance = 0;
 	};
 
-	const Variant *register_variant(const std::vector<std::pair<std::string, int>> *defines = nullptr);
+	const Variant *register_variant(const std::vector<std::pair<std::string, int>> *defines = nullptr,
+	                                const ImmutableSamplerBank *sampler_bank = nullptr);
 	void recompile();
 	void register_dependencies(ShaderManager &manager);
 
@@ -124,7 +126,8 @@ public:
 	}
 
 	void set_stage(Vulkan::ShaderStage stage, ShaderTemplate *shader);
-	ShaderProgramVariant *register_variant(const std::vector<std::pair<std::string, int>> &defines);
+	ShaderProgramVariant *register_variant(const std::vector<std::pair<std::string, int>> &defines,
+	                                       const ImmutableSamplerBank *sampler_bank = nullptr);
 
 private:
 	Device *device;

--- a/vulkan/sampler.cpp
+++ b/vulkan/sampler.cpp
@@ -25,11 +25,12 @@
 
 namespace Vulkan
 {
-Sampler::Sampler(Device *device_, VkSampler sampler_, const SamplerCreateInfo &info)
+Sampler::Sampler(Device *device_, VkSampler sampler_, const SamplerCreateInfo &info, bool immutable_)
     : Cookie(device_)
     , device(device_)
     , sampler(sampler_)
     , create_info(info)
+    , immutable(immutable_)
 {
 }
 
@@ -37,7 +38,9 @@ Sampler::~Sampler()
 {
 	if (sampler)
 	{
-		if (internal_sync)
+		if (immutable)
+			device->get_device_table().vkDestroySampler(device->get_device(), sampler, nullptr);
+		else if (internal_sync)
 			device->destroy_sampler_nolock(sampler);
 		else
 			device->destroy_sampler(sampler);
@@ -47,5 +50,77 @@ Sampler::~Sampler()
 void SamplerDeleter::operator()(Sampler *sampler)
 {
 	sampler->device->handle_pool.samplers.free(sampler);
+}
+
+VkSamplerCreateInfo Sampler::fill_vk_sampler_info(const SamplerCreateInfo &sampler_info)
+{
+	VkSamplerCreateInfo info = { VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
+
+	info.magFilter = sampler_info.mag_filter;
+	info.minFilter = sampler_info.min_filter;
+	info.mipmapMode = sampler_info.mipmap_mode;
+	info.addressModeU = sampler_info.address_mode_u;
+	info.addressModeV = sampler_info.address_mode_v;
+	info.addressModeW = sampler_info.address_mode_w;
+	info.mipLodBias = sampler_info.mip_lod_bias;
+	info.anisotropyEnable = sampler_info.anisotropy_enable;
+	info.maxAnisotropy = sampler_info.max_anisotropy;
+	info.compareEnable = sampler_info.compare_enable;
+	info.compareOp = sampler_info.compare_op;
+	info.minLod = sampler_info.min_lod;
+	info.maxLod = sampler_info.max_lod;
+	info.borderColor = sampler_info.border_color;
+	info.unnormalizedCoordinates = sampler_info.unnormalized_coordinates;
+	return info;
+}
+
+ImmutableSampler::ImmutableSampler(Util::Hash hash, Device *device_, const SamplerCreateInfo &sampler_info,
+                                   const ImmutableYcbcrConversion *ycbcr_)
+	: HashedObject<ImmutableSampler>(hash), device(device_), ycbcr(ycbcr_)
+{
+	VkSamplerYcbcrConversionInfoKHR conv_info = { VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO };
+	auto info = Sampler::fill_vk_sampler_info(sampler_info);
+
+	if (ycbcr)
+	{
+		conv_info.conversion = ycbcr->get_conversion();
+		info.pNext = &conv_info;
+	}
+
+#ifdef VULKAN_DEBUG
+	LOGI("Creating immutable sampler.\n");
+#endif
+
+	VkSampler vk_sampler = VK_NULL_HANDLE;
+	if (device->get_device_table().vkCreateSampler(device->get_device(), &info, nullptr, &vk_sampler) != VK_SUCCESS)
+		LOGE("Failed to create sampler.\n");
+
+#ifdef GRANITE_VULKAN_FOSSILIZE
+	register_sampler(vk_sampler, hash, info);
+#endif
+
+	sampler = SamplerHandle(device->handle_pool.samplers.allocate(device, vk_sampler, sampler_info, true));
+}
+
+ImmutableYcbcrConversion::ImmutableYcbcrConversion(Util::Hash hash, Device *device_,
+                                                   const VkSamplerYcbcrConversionCreateInfo &info)
+	: HashedObject<ImmutableYcbcrConversion>(hash), device(device_)
+{
+	if (device->get_device_features().sampler_ycbcr_conversion_features.samplerYcbcrConversion)
+	{
+		if (device->get_device_table().vkCreateSamplerYcbcrConversionKHR(device->get_device(), &info, nullptr,
+		                                                                 &conversion) != VK_SUCCESS)
+		{
+			LOGE("Failed to create YCbCr conversion.\n");
+		}
+	}
+	else
+		LOGE("Ycbcr conversion is not supported on this device.\n");
+}
+
+ImmutableYcbcrConversion::~ImmutableYcbcrConversion()
+{
+	if (conversion)
+		device->get_device_table().vkDestroySamplerYcbcrConversionKHR(device->get_device(), conversion, nullptr);
 }
 }


### PR DESCRIPTION
Do not reflect immutable samplers from shader,
instead, specify immutable samplers from API side.

Add a resource cache for samplers and YCbCr conversion as well.