### PR TITLE
add extension requirement for astc decoder shader

### DIFF
--- a/assets/shaders/decode/astc.comp
+++ b/assets/shaders/decode/astc.comp
@@ -22,6 +22,7 @@
  */
 
 #extension GL_EXT_samplerless_texture_functions : require
+#extension GL_GOOGLE_include_directive : require
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z = 4) in;
 
 #include "bitextract.h"


### PR DESCRIPTION
This is not strictly necessary depending on use but this makes glslangValidator happy when making a spirv binary of this shader.