### PR TITLE
Replace std::function with Util::SmallCallable in ThreadGroup

### DIFF
--- a/application/scene_viewer_application.cpp
+++ b/application/scene_viewer_application.cpp
@@ -146,10 +146,6 @@ void SceneViewerApplication::read_quirks(const std::string &path)
 		ImplementationQuirks::get().use_transient_color = doc["useTransientColor"].GetBool();
 	if (doc.HasMember("useTransientDepthStencil"))
 		ImplementationQuirks::get().use_transient_depth_stencil = doc["useTransientDepthStencil"].GetBool();
-	if (doc.HasMember("clusteringListIteration"))
-		ImplementationQuirks::get().clustering_list_iteration = doc["clusteringListIteration"].GetBool();
-	if (doc.HasMember("clusteringForceCPU"))
-		ImplementationQuirks::get().clustering_force_cpu = doc["clusteringForceCPU"].GetBool();
 	if (doc.HasMember("queueWaitOnSubmission"))
 		ImplementationQuirks::get().queue_wait_on_submission = doc["queueWaitOnSubmission"].GetBool();
 	if (doc.HasMember("stagingNeedDeviceLocal"))

--- a/assets/shaders/lights/clusterer_legacy.h
+++ b/assets/shaders/lights/clusterer_legacy.h
@@ -2,6 +2,7 @@
 #define CLUSTERER_LEGACY_H_
 
 #include "../inc/global_bindings.h"
+#include "../inc/helper_invocation.h"
 
 #define SPOT_LIGHT_SHADOW_ATLAS_SET 0
 #define SPOT_LIGHT_SHADOW_ATLAS_BINDING BINDING_GLOBAL_CLUSTER_SPOT_LEGACY

--- a/assets/shaders/lights/point.frag
+++ b/assets/shaders/lights/point.frag
@@ -56,9 +56,9 @@ void main()
 
     FragColor = compute_point_light(
 #ifdef INSTANCING
-        vIndex,
+        vIndex, point.data[vIndex],
 #else
-        0,
+        0, point.data[0],
 #endif
         base_color_ambient.rgb, N, mr.x, mr.y, pos, registers.camera_pos);
 }

--- a/assets/shaders/lights/spot.frag
+++ b/assets/shaders/lights/spot.frag
@@ -59,9 +59,9 @@ void main()
 
     FragColor = compute_spot_light(
 #ifdef INSTANCING
-        vIndex,
+        vIndex, spot.data[vIndex],
 #else
-        0,
+        0, spot.data[0],
 #endif
         base_color_ambient.rgb, N, mr.x, mr.y, pos, registers.camera_pos);
 }

--- a/renderer/lights/clusterer.hpp
+++ b/renderer/lights/clusterer.hpp
@@ -158,8 +158,6 @@ private:
 	unsigned max_spot_lights = MaxLights;
 	unsigned max_point_lights = MaxLights;
 	void build_cluster(Vulkan::CommandBuffer &cmd, Vulkan::ImageView &view, const Vulkan::ImageView *pre_culled);
-	void build_cluster_cpu(Vulkan::CommandBuffer &cmd, Vulkan::ImageView &view);
-	void build_cluster_bindless_cpu(Vulkan::CommandBuffer &cmd);
 	void build_cluster_bindless_gpu(Vulkan::CommandBuffer &cmd);
 	void on_device_created(const Vulkan::DeviceCreatedEvent &e);
 	void on_device_destroyed(const Vulkan::DeviceCreatedEvent &e);
@@ -194,8 +192,6 @@ private:
 		Vulkan::ShaderProgramVariant *cull_variant = nullptr;
 
 		mat4 cluster_transform;
-		std::vector<uint32_t> cluster_list_buffer;
-		std::mutex cluster_list_lock;
 
 		Vulkan::ShaderProgram *program = nullptr;
 		Vulkan::ImageView *target = nullptr;
@@ -214,32 +210,6 @@ private:
 	bool enable_volumetric_fog = false;
 	bool enable_volumetric_decals = false;
 	ShadowType shadow_type = ShadowType::PCF;
-
-	struct CPUGlobalAccelState
-	{
-		mat4 inverse_cluster_transform;
-		vec3 spot_position[MaxLights];
-		vec3 spot_direction[MaxLights];
-		float spot_size[MaxLights];
-		float spot_angle_sin[MaxLights];
-		float spot_angle_cos[MaxLights];
-		vec3 point_position[MaxLights];
-		float point_size[MaxLights];
-
-		vec3 inv_res;
-		float radius;
-	};
-
-	struct CPULocalAccelState
-	{
-		float cube_radius;
-		float world_scale_factor;
-		float z_bias;
-	};
-	uvec2 cluster_lights_cpu(int x, int y, int z,
-	                         const CPUGlobalAccelState &state,
-	                         const CPULocalAccelState &local,
-	                         float scale, uvec2 pre_mask);
 
 	void render_shadow_legacy(Vulkan::CommandBuffer &cmd,
 	                          const RenderContext &context,
@@ -304,14 +274,10 @@ private:
 
 	void update_bindless_descriptors(Vulkan::Device &device);
 	void update_bindless_data(Vulkan::CommandBuffer &cmd);
-	void update_bindless_range_buffer_cpu(Vulkan::CommandBuffer &cmd);
 	void update_bindless_range_buffer_gpu(Vulkan::CommandBuffer &cmd);
 	void update_bindless_range_buffer_decal_gpu(Vulkan::CommandBuffer &cmd);
-	void update_bindless_mask_buffer_cpu(Vulkan::CommandBuffer &cmd);
 	void update_bindless_mask_buffer_gpu(Vulkan::CommandBuffer &cmd);
 	void update_bindless_mask_buffer_decal_gpu(Vulkan::CommandBuffer &cmd);
-	void update_bindless_mask_buffer_spot(uint32_t *masks, unsigned index);
-	void update_bindless_mask_buffer_point(uint32_t *masks, unsigned index);
 	void begin_bindless_barriers(Vulkan::CommandBuffer &cmd);
 	void end_bindless_barriers(Vulkan::CommandBuffer &cmd);
 

--- a/renderer/lights/volumetric_diffuse.cpp
+++ b/renderer/lights/volumetric_diffuse.cpp
@@ -533,13 +533,13 @@ TaskGroupHandle VolumetricDiffuseLightManager::create_probe_gbuffer(TaskComposer
 	list_info.domain = Vulkan::BufferDomain::Device;
 	light.light.set_buffers(device.create_buffer(atomics_info), device.create_buffer(list_info));
 
-	RenderPassSceneRenderer::Setup setup = {};
-	setup.flags = SCENE_RENDERER_DEFERRED_GBUFFER_BIT |
-	              SCENE_RENDERER_SKIP_UNBOUNDED_BIT |
-	              SCENE_RENDERER_SKIP_OPAQUE_FLOATING_BIT;
-	setup.deferred_lights = nullptr;
-	setup.suite = suite;
-	setup.scene = scene;
+	auto setup = std::make_shared<RenderPassSceneRenderer::Setup>();
+	setup->flags = SCENE_RENDERER_DEFERRED_GBUFFER_BIT |
+	               SCENE_RENDERER_SKIP_UNBOUNDED_BIT |
+	               SCENE_RENDERER_SKIP_OPAQUE_FLOATING_BIT;
+	setup->deferred_lights = nullptr;
+	setup->suite = suite;
+	setup->scene = scene;
 
 	TaskComposer probe_composer(*incoming.get_thread_group());
 	probe_composer.set_incoming_task(composer.get_pipeline_stage_dependency());
@@ -558,7 +558,7 @@ TaskGroupHandle VolumetricDiffuseLightManager::create_probe_gbuffer(TaskComposer
 	{
 		render_stage.enqueue_task([this, z, &light, setup, &device]() {
 			ContextRenderers renderers;
-			setup_cube_renderer(renderers, device, setup, light.light.get_resolution().x);
+			setup_cube_renderer(renderers, device, *setup, light.light.get_resolution().x);
 			render_probe_gbuffer_slice(light, device, renderers, z);
 		});
 	}

--- a/renderer/threaded_scene.cpp
+++ b/renderer/threaded_scene.cpp
@@ -68,51 +68,43 @@ void scene_gather_transparent_renderables(const Scene &scene, TaskComposer &comp
 }
 
 void scene_gather_static_shadow_renderables(const Scene &scene, TaskComposer &composer, const Frustum &frustum,
-                                            VisibilityList *lists, Util::Hash *transform_hashes, unsigned num_tasks,
-                                            const std::function<bool ()> &func)
+                                            VisibilityList *lists, Util::Hash *transform_hashes, unsigned num_tasks)
 {
 	auto &group = composer.begin_pipeline_stage();
 	group.set_desc("gather-static-shadow-renderables");
 	for (unsigned i = 0; i < num_tasks; i++)
 	{
-		group.enqueue_task([&frustum, lists, &scene, i, num_tasks, func, transform_hashes]() {
+		group.enqueue_task([&frustum, lists, &scene, i, num_tasks, transform_hashes]() {
 			if (transform_hashes)
 				transform_hashes[i] = 0;
 
-			if (!func || func())
-			{
-				scene.gather_visible_static_shadow_renderables_subset(frustum, lists[i], i, num_tasks);
+			scene.gather_visible_static_shadow_renderables_subset(frustum, lists[i], i, num_tasks);
 
-				// This way of combining hashes is order independent and serves as a good way of hashing the overall scene.
-				if (transform_hashes)
-					for (auto &v : lists[i])
-						transform_hashes[i] ^= v.transform_hash;
-			}
+			// This way of combining hashes is order independent and serves as a good way of hashing the overall scene.
+			if (transform_hashes)
+				for (auto &v : lists[i])
+					transform_hashes[i] ^= v.transform_hash;
 		});
 	}
 }
 
 void scene_gather_dynamic_shadow_renderables(const Scene &scene, TaskComposer &composer, const Frustum &frustum,
-                                             VisibilityList *lists, Util::Hash *transform_hashes, unsigned num_tasks,
-                                             const std::function<bool ()> &func)
+                                             VisibilityList *lists, Util::Hash *transform_hashes, unsigned num_tasks)
 {
 	auto &group = composer.begin_pipeline_stage();
 	group.set_desc("gather-dynamic-shadow-renderables");
 	for (unsigned i = 0; i < num_tasks; i++)
 	{
-		group.enqueue_task([&frustum, lists, &scene, i, num_tasks, func, transform_hashes]() {
+		group.enqueue_task([&frustum, lists, &scene, i, num_tasks, transform_hashes]() {
 			if (transform_hashes)
 				transform_hashes[i] = 0;
 
-			if (!func || func())
-			{
-				scene.gather_visible_dynamic_shadow_renderables_subset(frustum, lists[i], i, num_tasks);
+			scene.gather_visible_dynamic_shadow_renderables_subset(frustum, lists[i], i, num_tasks);
 
-				// This way of combining hashes is order independent and serves as a good way of hashing the overall scene.
-				if (transform_hashes)
-					for (auto &v : lists[i])
-						transform_hashes[i] ^= v.transform_hash;
-			}
+			// This way of combining hashes is order independent and serves as a good way of hashing the overall scene.
+			if (transform_hashes)
+				for (auto &v : lists[i])
+					transform_hashes[i] ^= v.transform_hash;
 		});
 	}
 }

--- a/renderer/threaded_scene.hpp
+++ b/renderer/threaded_scene.hpp
@@ -41,10 +41,10 @@ void scene_gather_transparent_renderables(const Scene &scene, TaskComposer &comp
                                           VisibilityList *lists, unsigned num_tasks);
 void scene_gather_static_shadow_renderables(const Scene &scene, TaskComposer &composer, const Frustum &frustum,
                                             VisibilityList *lists, Util::Hash *transform_hashes,
-                                            unsigned num_tasks, const std::function<bool ()> &cond = {});
+                                            unsigned num_tasks);
 void scene_gather_dynamic_shadow_renderables(const Scene &scene, TaskComposer &composer, const Frustum &frustum,
                                              VisibilityList *lists, Util::Hash *transform_hashes,
-                                             unsigned num_tasks, const std::function<bool ()> &cond = {});
+                                             unsigned num_tasks);
 void scene_gather_positional_light_renderables(const Scene &scene, TaskComposer &composer, const Frustum &frustum,
                                                VisibilityList *lists, unsigned num_tasks);
 void scene_gather_positional_light_renderables_sorted(const Scene &scene, TaskComposer &composer, const RenderContext &context,

--- a/scene-export/texture_compression.cpp
+++ b/scene-export/texture_compression.cpp
@@ -158,20 +158,20 @@ struct CompressorState : std::enable_shared_from_this<CompressorState>
 	unsigned block_size_x = 1;
 	unsigned block_size_y = 1;
 
-	void setup(const CompressorArguments &args);
-	void enqueue_compression(ThreadGroup &group, const CompressorArguments &args);
-	void enqueue_compression_block_ispc(TaskGroupHandle &group, const CompressorArguments &args, unsigned layer, unsigned level);
-	void enqueue_compression_block_astc(TaskGroupHandle &group, const CompressorArguments &args, unsigned layer, unsigned level, TextureMode mode);
-	void enqueue_compression_block_rgtc(TaskGroupHandle &group, const CompressorArguments &args, unsigned layer, unsigned level);
-	void enqueue_compression_copy_8bit(TaskGroupHandle &group, const CompressorArguments &, unsigned layer, unsigned level);
-	void enqueue_compression_copy_16bit(TaskGroupHandle &group, const CompressorArguments &, unsigned layer, unsigned level);
+	void setup();
+	void enqueue_compression(ThreadGroup &group);
+	void enqueue_compression_block_ispc(TaskGroupHandle &group, unsigned layer, unsigned level);
+	void enqueue_compression_block_astc(TaskGroupHandle &group, unsigned layer, unsigned level, TextureMode mode);
+	void enqueue_compression_block_rgtc(TaskGroupHandle &group, unsigned layer, unsigned level);
+	void enqueue_compression_copy_8bit(TaskGroupHandle &group, unsigned layer, unsigned level);
+	void enqueue_compression_copy_16bit(TaskGroupHandle &group, unsigned layer, unsigned level);
 
 	double total_error[4] = {};
 	std::mutex lock;
 	TaskSignal *signal = nullptr;
 };
 
-void CompressorState::setup(const CompressorArguments &args)
+void CompressorState::setup()
 {
 	output->set_swizzle(args.output_mapping);
 	output->set_generate_mipmaps_on_load(args.deferred_mipgen);
@@ -439,8 +439,7 @@ void CompressorState::setup(const CompressorArguments &args)
 	}
 }
 
-void CompressorState::enqueue_compression_copy_16bit(TaskGroupHandle &group, const CompressorArguments &,
-                                                     unsigned layer, unsigned level)
+void CompressorState::enqueue_compression_copy_16bit(TaskGroupHandle &group, unsigned layer, unsigned level)
 {
 	group->enqueue_task([=]() {
 		auto &input_layout = input->get_layout();
@@ -470,8 +469,7 @@ void CompressorState::enqueue_compression_copy_16bit(TaskGroupHandle &group, con
 	});
 }
 
-void CompressorState::enqueue_compression_copy_8bit(TaskGroupHandle &group, const CompressorArguments &,
-                                                    unsigned layer, unsigned level)
+void CompressorState::enqueue_compression_copy_8bit(TaskGroupHandle &group, unsigned layer, unsigned level)
 {
 	group->enqueue_task([=]() {
 		auto &input_layout = input->get_layout();
@@ -501,7 +499,7 @@ void CompressorState::enqueue_compression_copy_8bit(TaskGroupHandle &group, cons
 	});
 }
 
-void CompressorState::enqueue_compression_block_rgtc(TaskGroupHandle &group, const CompressorArguments &args, unsigned layer, unsigned level)
+void CompressorState::enqueue_compression_block_rgtc(TaskGroupHandle &group, unsigned layer, unsigned level)
 {
 	int width = input->get_layout().get_width(level);
 	int height = input->get_layout().get_height(level);
@@ -603,8 +601,7 @@ void CompressorState::enqueue_compression_block_rgtc(TaskGroupHandle &group, con
 }
 
 #ifdef HAVE_ISPC
-void CompressorState::enqueue_compression_block_ispc(TaskGroupHandle &group, const CompressorArguments &args,
-                                                     unsigned layer, unsigned level)
+void CompressorState::enqueue_compression_block_ispc(TaskGroupHandle &group, unsigned layer, unsigned level)
 {
 	int width = input->get_layout().get_width(level);
 	int height = input->get_layout().get_height(level);
@@ -729,7 +726,7 @@ void CompressorState::enqueue_compression_block_ispc(TaskGroupHandle &group, con
 #endif
 
 #ifdef HAVE_ASTC_ENCODER
-void CompressorState::enqueue_compression_block_astc(TaskGroupHandle &compression_task, const CompressorArguments &args,
+void CompressorState::enqueue_compression_block_astc(TaskGroupHandle &compression_task,
                                                      unsigned layer, unsigned level, TextureMode mode)
 {
 	struct ContextDeleter
@@ -855,7 +852,7 @@ void CompressorState::enqueue_compression_block_astc(TaskGroupHandle &compressio
 }
 #endif
 
-void CompressorState::enqueue_compression(ThreadGroup &group, const CompressorArguments &args)
+void CompressorState::enqueue_compression(ThreadGroup &group)
 {
 	auto compression_task = group.create_task();
 
@@ -867,7 +864,7 @@ void CompressorState::enqueue_compression(ThreadGroup &group, const CompressorAr
 			{
 			case VK_FORMAT_BC4_UNORM_BLOCK:
 			case VK_FORMAT_BC5_UNORM_BLOCK:
-				enqueue_compression_block_rgtc(compression_task, args, layer, level);
+				enqueue_compression_block_rgtc(compression_task, layer, level);
 				break;
 
 			case VK_FORMAT_BC6H_UFLOAT_BLOCK:
@@ -880,7 +877,7 @@ void CompressorState::enqueue_compression(ThreadGroup &group, const CompressorAr
 			case VK_FORMAT_BC3_SRGB_BLOCK:
 			case VK_FORMAT_BC3_UNORM_BLOCK:
 #ifdef HAVE_ISPC
-				enqueue_compression_block_ispc(compression_task, args, layer, level);
+				enqueue_compression_block_ispc(compression_task, layer, level);
 #endif
 				break;
 
@@ -894,12 +891,12 @@ void CompressorState::enqueue_compression(ThreadGroup &group, const CompressorAr
 			case VK_FORMAT_ASTC_8x8_UNORM_BLOCK:
 #ifdef HAVE_ISPC
 				if (!use_astc_encoder)
-					enqueue_compression_block_ispc(compression_task, args, layer, level);
+					enqueue_compression_block_ispc(compression_task, layer, level);
 				else
 #endif
 				{
 #ifdef HAVE_ASTC_ENCODER
-					enqueue_compression_block_astc(compression_task, args, layer, level, args.mode);
+					enqueue_compression_block_astc(compression_task, layer, level, args.mode);
 #endif
 				}
 				break;
@@ -909,7 +906,7 @@ void CompressorState::enqueue_compression(ThreadGroup &group, const CompressorAr
 			case VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT:
 			case VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT:
 #ifdef HAVE_ASTC_ENCODER
-				enqueue_compression_block_astc(compression_task, args, layer, level, args.mode);
+				enqueue_compression_block_astc(compression_task, layer, level, args.mode);
 #endif
 				break;
 
@@ -917,13 +914,13 @@ void CompressorState::enqueue_compression(ThreadGroup &group, const CompressorAr
 			case VK_FORMAT_R8G8B8A8_UNORM:
 			case VK_FORMAT_R8G8_UNORM:
 			case VK_FORMAT_R8_UNORM:
-				enqueue_compression_copy_8bit(compression_task, args, layer, level);
+				enqueue_compression_copy_8bit(compression_task, layer, level);
 				break;
 
 			case VK_FORMAT_R16G16B16A16_SFLOAT:
 			case VK_FORMAT_R16G16_SFLOAT:
 			case VK_FORMAT_R16_SFLOAT:
-				enqueue_compression_copy_16bit(compression_task, args, layer, level);
+				enqueue_compression_copy_16bit(compression_task, layer, level);
 				break;
 
 			default:
@@ -973,30 +970,29 @@ bool compress_texture(ThreadGroup &group, const CompressorArguments &args,
 	auto setup_task = group.create_task([&group, output]() {
 		output->output = std::make_shared<Vulkan::MemoryMappedTexture>();
 		auto &layout = output->input->get_layout();
-		auto &args = output->args;
 
-		output->setup(args);
+		output->setup();
 
 		switch (layout.get_image_type())
 		{
 		case VK_IMAGE_TYPE_1D:
-			output->output->set_1d(args.format, layout.get_width(), layout.get_layers(), layout.get_levels());
+			output->output->set_1d(output->args.format, layout.get_width(), layout.get_layers(), layout.get_levels());
 			break;
 		case VK_IMAGE_TYPE_2D:
 			if (output->input->get_flags() & Vulkan::MEMORY_MAPPED_TEXTURE_CUBE_MAP_COMPATIBLE_BIT)
-				output->output->set_cube(args.format, layout.get_width(), layout.get_layers() / 6, layout.get_levels());
+				output->output->set_cube(output->args.format, layout.get_width(), layout.get_layers() / 6, layout.get_levels());
 			else
-				output->output->set_2d(args.format, layout.get_width(), layout.get_height(), layout.get_layers(), layout.get_levels());
+				output->output->set_2d(output->args.format, layout.get_width(), layout.get_height(), layout.get_layers(), layout.get_levels());
 			break;
 		case VK_IMAGE_TYPE_3D:
-			output->output->set_3d(args.format, layout.get_width(), layout.get_depth(), layout.get_levels());
+			output->output->set_3d(output->args.format, layout.get_width(), layout.get_depth(), layout.get_levels());
 			break;
 		default:
 			LOGE("Unsupported image type.\n");
 			return;
 		}
 
-		if (!output->output->map_write(*GRANITE_FILESYSTEM(), args.output))
+		if (!output->output->map_write(*GRANITE_FILESYSTEM(), output->args.output))
 		{
 			LOGE("Failed to map output texture for writing.\n");
 			if (output->signal)
@@ -1007,7 +1003,7 @@ bool compress_texture(ThreadGroup &group, const CompressorArguments &args,
 		LOGI("Mapping %u bytes for texture writeout.\n",
 		     unsigned(output->output->get_required_size()));
 
-		output->enqueue_compression(group, args);
+		output->enqueue_compression(group);
 	});
 	group.add_dependency(*setup_task, *dep);
 

--- a/tests/async_spec_constant.cpp
+++ b/tests/async_spec_constant.cpp
@@ -60,8 +60,8 @@ struct AsyncSpecConstantApplication : Granite::Application, Granite::EventHandle
 			if (pending_pipelines.count(compile.hash) == 0)
 			{
 				LOGI("Enqueueing pipeline compile for spec constant %u.\n", value);
-				GRANITE_THREAD_GROUP()->create_task([&device, compile]() {
-					CommandBuffer::build_graphics_pipeline(&device, compile, CommandBuffer::CompileMode::AsyncThread);
+				GRANITE_THREAD_GROUP()->create_task([&device, c = std::make_unique<DeferredPipelineCompile>(compile)]() {
+					CommandBuffer::build_graphics_pipeline(&device, *c, CommandBuffer::CompileMode::AsyncThread);
 				});
 				pending_pipelines.insert(compile.hash);
 			}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -28,6 +28,7 @@ add_granite_internal_lib(granite-util
         lru_cache.hpp
         unordered_array.hpp
         message_queue.hpp message_queue.cpp
+        small_callable.hpp
         no_init_pod.hpp)
 target_include_directories(granite-util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(granite-util PUBLIC granite-application-global-interface)

--- a/util/small_callable.hpp
+++ b/util/small_callable.hpp
@@ -1,0 +1,141 @@
+/* Copyright (c) 2017-2022 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <type_traits>
+#include <utility>
+#include <functional>
+
+namespace Util
+{
+template <typename Sig, size_t PayloadSize, size_t Align>
+class SmallCallable;
+
+template <typename R, typename... Params, size_t PayloadSize, size_t Align>
+class SmallCallable<R (Params...), PayloadSize, Align>
+{
+public:
+	inline R call(Params... params)
+	{
+		return get_invokable().call(std::forward<Params>(params)...);
+	}
+
+	inline explicit operator bool() const
+	{
+		return get_invokable().active();
+	}
+
+	~SmallCallable()
+	{
+		get_invokable().~Invokable();
+	}
+
+	template <typename Func>
+	inline explicit SmallCallable(Func&& fn)
+	{
+		using PlainFunc = std::remove_cv_t<std::remove_reference_t<Func>>;
+		// Avoid mistaken double-wrap.
+		static_assert(!std::is_same<std::function<R (Params...)>, PlainFunc>::value, "std::function not supported.");
+		static_assert(sizeof(CapturedInvokable<PlainFunc>) <= sizeof(payload), "Callback payload is too large.");
+		new(payload) CapturedInvokable<PlainFunc>(std::forward<Func>(fn));
+	}
+
+	inline explicit SmallCallable(R (*fn)(Params...))
+	{
+		static_assert(sizeof(CapturedPlain) <= sizeof(payload), "Callback payload is too large.");
+		new(payload) CapturedPlain(fn);
+	}
+
+	template <typename T>
+	inline SmallCallable(T *ptr, R (T::*memb)(Params...))
+	{
+		using MemberFunc = CapturedMemberFunc<T>;
+		static_assert(sizeof(MemberFunc) <= sizeof(payload), "Callback payload is too large.");
+		new(payload) MemberFunc(ptr, memb);
+	}
+
+	inline SmallCallable()
+	{
+		new(payload) NullInvoker();
+	}
+
+	SmallCallable(const SmallCallable &) = delete;
+	SmallCallable(SmallCallable &&) = delete;
+	void operator=(const SmallCallable &) = delete;
+	void operator=(SmallCallable &&) = delete;
+
+private:
+	struct Invokable
+	{
+		virtual ~Invokable() = default;
+		virtual R call(Params...) = 0;
+		virtual bool active() const = 0;
+	};
+
+	template <typename I>
+	struct CapturedInvokable final : Invokable
+	{
+		explicit CapturedInvokable(I&& holder_) : holder(std::move(holder_)) {}
+		R call(Params... params) override { return holder(std::forward<Params>(params)...); };
+		bool active() const override { return true; }
+		I holder;
+	};
+
+	struct NullInvoker final : Invokable
+	{
+		R call(Params...) override { return R(); }
+		bool active() const override { return false; }
+	};
+
+	struct CapturedPlain final : Invokable
+	{
+		explicit CapturedPlain(R (*func_)(Params...)) : func(func_) {}
+		R call(Params... params) override { return func(std::forward<Params>(params)...); }
+		bool active() const override { return func != nullptr; }
+		R (*func)(Params...);
+	};
+
+	template <typename T>
+	struct CapturedMemberFunc final : Invokable
+	{
+		explicit CapturedMemberFunc(T *ptr_, R (T::*func_)(Params...)) : ptr(ptr_), func(func_) {}
+		R call(Params... params) override { return (ptr->*func)(std::forward<Params>(params)...); }
+		bool active() const override { return ptr != nullptr && func != nullptr; }
+		T *ptr;
+		R (T::*func)(Params...);
+	};
+
+	Invokable &get_invokable()
+	{
+		return *reinterpret_cast<Invokable *>(&payload[0]);
+	}
+
+	const Invokable &get_invokable() const
+	{
+		return *reinterpret_cast<const Invokable *>(&payload[0]);
+	}
+
+	alignas(Align) char payload[PayloadSize];
+};
+}

--- a/viewer/quirks.json
+++ b/viewer/quirks.json
@@ -3,8 +3,6 @@
 	"mergeSubpasses" : true,
 	"useTransientColor": true,
 	"useTransientDepthStencil": true,
-	"clusteringListIteration": false,
-	"clusteringForceCPU": false,
 	"queueWaitOnSubmission": false,
 	"stagingNeedDeviceLocal" : false,
 	"useAsyncComputePost": true,

--- a/vulkan/device_fossilize.cpp
+++ b/vulkan/device_fossilize.cpp
@@ -228,8 +228,9 @@ bool Device::enqueue_create_graphics_pipeline(Fossilize::Hash hash,
 
 	if (replayer_state.pipeline_group)
 	{
-		replayer_state.pipeline_group->enqueue_task([this, info = *create_info, hash, pipeline]() mutable {
-			*pipeline = fossilize_create_graphics_pipeline(hash, info);
+		replayer_state.pipeline_group->enqueue_task([this, create_info, hash, pipeline]() {
+			auto tmp_create_info = *create_info;
+			*pipeline = fossilize_create_graphics_pipeline(hash, tmp_create_info);
 		});
 		return true;
 	}
@@ -268,8 +269,9 @@ bool Device::enqueue_create_compute_pipeline(Fossilize::Hash hash,
 
 	if (replayer_state.pipeline_group)
 	{
-		replayer_state.pipeline_group->enqueue_task([this, info = *create_info, hash, pipeline]() mutable {
-			*pipeline = fossilize_create_compute_pipeline(hash, info);
+		replayer_state.pipeline_group->enqueue_task([this, create_info, hash, pipeline]() {
+			auto tmp_create_info = *create_info;
+			*pipeline = fossilize_create_compute_pipeline(hash, tmp_create_info);
 		});
 		return true;
 	}

--- a/vulkan/device_fossilize.cpp
+++ b/vulkan/device_fossilize.cpp
@@ -229,6 +229,7 @@ bool Device::enqueue_create_graphics_pipeline(Fossilize::Hash hash,
 	if (replayer_state.pipeline_group)
 	{
 		replayer_state.pipeline_group->enqueue_task([this, create_info, hash, pipeline]() {
+			// The lifetime of create_info is tied to the replayer itself.
 			auto tmp_create_info = *create_info;
 			*pipeline = fossilize_create_graphics_pipeline(hash, tmp_create_info);
 		});
@@ -270,6 +271,7 @@ bool Device::enqueue_create_compute_pipeline(Fossilize::Hash hash,
 	if (replayer_state.pipeline_group)
 	{
 		replayer_state.pipeline_group->enqueue_task([this, create_info, hash, pipeline]() {
+			// The lifetime of create_info is tied to the replayer itself.
 			auto tmp_create_info = *create_info;
 			*pipeline = fossilize_create_compute_pipeline(hash, tmp_create_info);
 		});

--- a/vulkan/quirks.hpp
+++ b/vulkan/quirks.hpp
@@ -30,8 +30,6 @@ struct ImplementationQuirks
 	bool merge_subpasses = true;
 	bool use_transient_color = true;
 	bool use_transient_depth_stencil = true;
-	bool clustering_list_iteration = false;
-	bool clustering_force_cpu = false;
 	bool queue_wait_on_submission = false;
 	bool staging_need_device_local = false;
 	bool use_async_compute_post = true;


### PR DESCRIPTION
Guarantees that the callback requires no allocation and keeps us from capturing arbitrary large monster lambdas.