### PR TITLE
util: fix the musl build

### DIFF
--- a/util/aligned_alloc.cpp
+++ b/util/aligned_alloc.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "aligned_alloc.hpp"
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef _WIN32


### PR DESCRIPTION
I initially ran into this as part of the parallel-rdp-standalone build.
```
samu: job failed with status 1: /usr/lib/ccache/bin/c++  -I/tmp/Granite/util -I/tmp/Granite/application/global -std=gnu++14 -Wshadow -Wall -Wextra -Wno-comment -Wno-missing-field-initializers -Wno-empty-body -fno-omit-frame-pointer -msse3 -ffast-math -MD -MT util/CMakeFiles/granite-util.dir/aligned_alloc.cpp.o -MF util/CMakeFiles/granite-util.dir/aligned_alloc.cpp.o.d -o util/CMakeFiles/granite-util.dir/aligned_alloc.cpp.o -c /tmp/Granite/util/aligned_alloc.cpp /tmp/Granite/util/aligned_alloc.cpp: In function 'void* Util::memalign_alloc(size_t, size_t)': /tmp/Granite/util/aligned_alloc.cpp:47:5: error: 'uintptr_t' was not declared in this scope
   47 |     uintptr_t addr = 0;
      |     ^~~~~~~~~
/tmp/Granite/util/aligned_alloc.cpp:27:1: note: 'uintptr_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   26 | #include <string.h>
  +++ |+#include <cstdint>
   27 | #ifdef _WIN32
/tmp/Granite/util/aligned_alloc.cpp:53:5: error: 'addr' was not declared in this scope
   53 |     addr = ((uintptr_t)ptr + sizeof(uintptr_t) + boundary) & ~(boundary - 1);
      |     ^~~~
/tmp/Granite/util/aligned_alloc.cpp:53:24: error: expected ')' before 'ptr'
   53 |     addr = ((uintptr_t)ptr + sizeof(uintptr_t) + boundary) & ~(boundary - 1);
      |            ~           ^~~
      |                        )
samu: subcommand failed
```