### PR TITLE
Account for macOS when defining pthread functions

### DIFF
--- a/util/thread_name.cpp
+++ b/util/thread_name.cpp
@@ -22,7 +22,7 @@
 
 #include "thread_name.hpp"
 
-#ifdef __linux__
+#if !defined(_WIN32)
 #include <pthread.h>
 #else
 #define WIN32_LEAN_AND_MEAN
@@ -34,9 +34,11 @@ namespace Util
 {
 void set_current_thread_name(const char *name)
 {
-#ifdef __linux__
+#if defined(__linux__)
 	pthread_setname_np(pthread_self(), name);
-#else
+#elif defined(__APPLE__)
+	pthread_setname_np(name);
+#elif defined(_WIN32)
 	using PFN_SetThreadDescription = HRESULT (WINAPI *)(HANDLE, PCWSTR);
 	auto module = GetModuleHandleA("kernel32.dll");
 	PFN_SetThreadDescription SetThreadDescription = module ? reinterpret_cast<PFN_SetThreadDescription>(


### PR DESCRIPTION
Building paraLLEl-RDP as a standalone codebase has generally worked on macOS. The ability to do so was recently (ish) broken by https://github.com/Themaister/Granite/commit/2265b6936df0698de8ee528d6c458c500b0a1851, which imports `<pthread.h>` only on Linux, and otherwise assumed a Windows environment.

This PR addresses that issue by importing pthreads on any non-Windows platform. I also went ahead and implemented the name setter for Apple platforms, which just meant accounting for the different function signature (you can only set a pthread name on Apple platforms from that thread, hence the function does not take the pthread object or tid as an argument).

The standalone version of paraLLEl-RDP only seems to use this name setting function once, when creating traces. Hence, this isn't adding meaningful functionality, rather just un-breaking the standalone paraLLEl-RDP build for Mac users really.

No worries if you are reluctant to add Apple platform-specific code to Granite and want to close this and handle the definition logic differently, I just figured I would go ahead and contribute a fix once I identified the issue. Thanks for taking the time.