### PR TITLE
filesystem: Include macOS in BSD defines

### DIFF
--- a/filesystem/linux/os_filesystem.cpp
+++ b/filesystem/linux/os_filesystem.cpp
@@ -39,11 +39,12 @@
 #include <sys/inotify.h>
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define FSTAT64 fstat
 #define FTRUNCATE64 ftruncate
 #define MMAP64 mmap
 #define STAT64 stat
+#define off64_t off_t
 #else
 #define FSTAT64 fstat64
 #define FTRUNCATE64 ftruncate64


### PR DESCRIPTION
Context: Building slangmosh for paraLLEl-RDP standalone builds on macOS requires the filesystem target. Was not building because of BSD-style filesystem definitions.

Also add a define for off64_t which I don't think exists on BSD. I don't have a BSD system to test on, but using `off_t` was required for macOS as well.