### PR TITLE
Allow loading MoltenVK via the Vulkan Loader

### DIFF
--- a/vulkan/context.cpp
+++ b/vulkan/context.cpp
@@ -736,6 +736,10 @@ bool Context::create_instance(const char * const *instance_ext, uint32_t instanc
 		}
 	}
 
+	// Permit MoltenVK (and other portability drivers) when enumerating drivers via the Vulkan loader.
+	info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+	instance_exts.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+
 	if (inherit_info)
 	{
 		info.enabledExtensionCount = inherit_info->enabledExtensionCount;


### PR DESCRIPTION
Now that multiple viable Vulkan implementations exist on macOS, using the Vulkan loader to load one of several available drivers will become more commonplace on macOS.

To allow the use of MoltenVK from an application standpoint, if using the Vulkan loader, one must enable the relevant extension, as well as set the portability enumeration bit in the `VKCreateInstanceInfo` flags.

This will allow macOS applications integrating Granite to use the Vulkan loader to select between MoltenVK and KosmicKrisp.