### PR TITLE
Fix Windows ARM64 builds.

### DIFF
--- a/math/simd_headers.hpp
+++ b/math/simd_headers.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
 
 #include <intrin.h>
 #if defined(_INCLUDED_PMM) && !defined(__SSE3__)


### PR DESCRIPTION
Windows on ARM builds fail because `math/simd_headers.hpp` unconditionally enables SSE headers on MSVC hosts. This is wrong, ARM64 Windows hosts also have `_MSC_VER` set but obviously do not support SSE.

Adding a check for x86/64 fixes the issue, and it additionally allows checking for NEON support on Windows hosts that support it.